### PR TITLE
Some improvements and bugfixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>4.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>6.4.0</version>
+        </dependency>
+
 
         <!-- Logs -->
         <dependency>

--- a/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
+++ b/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
@@ -1,5 +1,7 @@
 package com.chavaillaz.jaxb.stream;
 
+import static org.codehaus.stax2.XMLOutputFactory2.P_AUTOMATIC_EMPTY_ELEMENTS;
+import com.ctc.wstx.stax.WstxOutputFactory;
 import com.sun.xml.txw2.output.IndentingXMLStreamWriter;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
@@ -11,7 +13,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.xml.namespace.QName;
-import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.Closeable;
@@ -90,7 +91,9 @@ public class StreamingMarshaller implements Closeable {
             close();
         }
 
-        xmlWriter = new IndentingXMLStreamWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(outputStream, "UTF-8"));
+        WstxOutputFactory wstxOutputFactory = new WstxOutputFactory();
+        wstxOutputFactory.setProperty(P_AUTOMATIC_EMPTY_ELEMENTS, true);
+        xmlWriter = new IndentingXMLStreamWriter(wstxOutputFactory.createXMLStreamWriter(outputStream, "UTF-8"));
         createDocumentStart();
     }
 

--- a/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
+++ b/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
@@ -90,7 +90,7 @@ public class StreamingMarshaller implements Closeable {
             close();
         }
 
-        xmlWriter = new IndentingXMLStreamWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(outputStream));
+        xmlWriter = new IndentingXMLStreamWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(outputStream, "UTF-8"));
         createDocumentStart();
     }
 

--- a/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
+++ b/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
@@ -47,8 +47,8 @@ import static java.lang.Boolean.TRUE;
 public class StreamingMarshaller implements Closeable {
 
     private final Map<Class<?>, Marshaller> marshallerCache = new HashMap<>();
-    private final String rootElement;
-    private XMLStreamWriter xmlWriter;
+    protected final String rootElement;
+    protected XMLStreamWriter xmlWriter;
 
     /**
      * Creates a new streaming marshaller writing elements in the given root element class.

--- a/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
+++ b/src/main/java/com/chavaillaz/jaxb/stream/StreamingMarshaller.java
@@ -172,6 +172,7 @@ public class StreamingMarshaller implements Closeable {
     public synchronized void close() {
         try {
             if (xmlWriter != null) {
+                xmlWriter.writeCharacters("\n");
                 xmlWriter.writeEndDocument();
                 xmlWriter.close();
             }


### PR DESCRIPTION
1. Use single empty tag. Changing `<tag></tag>` to `<tag />`. This change can reduce the file size by a lot for a big xml file.
2. Write the last closing tag on a new line. Before this change, the last tag is on the same line of the previous tag.
```xml
  <tag2/><tag1/>
```
vs
```xml
  <tag2/>
<tag1/>
```
3. Set the xml's encoding to UTF-8. Before, it uses another not-so-common one.
4. Change `rootElement` and `xmlWriter` to protected so that the inherited class can modify it. After inheriting the  `StreamingMarshaller` class, we normally want to override the `xmlWriter` to set addition properties, etc.

Best,

Fengchao